### PR TITLE
Release v0.5.2

### DIFF
--- a/pkg/client.go
+++ b/pkg/client.go
@@ -142,7 +142,8 @@ func GetTarget(target string) (t string) {
     parts := strings.Split(user.Username, "\\")
     var un string
     if len(parts) > 0 {
-        un = parts[len(parts)-1]
+        un_anycase := parts[len(parts)-1]
+		un = strings.ToLower(un_anycase)
     } else {
         err := fmt.Sprintf("Username cannot be determined from: %s", user)
         zap.S().Fatal(err)

--- a/pkg/client.go
+++ b/pkg/client.go
@@ -143,7 +143,7 @@ func GetTarget(target string) (t string) {
     var un string
     if len(parts) > 0 {
         un_anycase := parts[len(parts)-1]
-		un = strings.ToLower(un_anycase)
+        un = strings.ToLower(un_anycase)
     } else {
         err := fmt.Sprintf("Username cannot be determined from: %s", user)
         zap.S().Fatal(err)


### PR DESCRIPTION
when users sign in to their laptop they can use lower and upper case letters to do so, eg White_eu, WhiTe_eu. The script is expecting it to be lowercase eg white_eu as this is what the ec2 instance is tagged with. This will allow users to put in any case and correctly pick their devbox instance id